### PR TITLE
Fix cemOpts for components with no attributes

### DIFF
--- a/wc/.storybook/cemOpts.ts
+++ b/wc/.storybook/cemOpts.ts
@@ -19,7 +19,7 @@ export const setCustomElementsManifestWithOptions = (
     }
     if (!mapMembersToAttributes) {
         actOnDeclarations(customElements, declaration => {
-            const attrs = declaration.attributes;
+            const attrs = declaration.attributes || [];
             const members = declaration.members;
             // Members includes all attributes, properties, and internal fields,
             // whether private or not. Attributes are the members marked with


### PR DESCRIPTION
Previously, Storybook would crash if we had a WC that took no props.