### PR TITLE
Create LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,28 +26,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-=======================================================================
-
-“Commons Clause” License Condition v1.0
-
-The Software is provided to you by the Licensor under the License, as defined
-below, subject to the following condition.
-
-Without limiting other conditions in the License, the grant of rights under
-the License will not include, and the License does not grant to you, the right
-to Sell the Software.
-
-For purposes of the foregoing, “Sell” means practicing any or all of the rights
-granted to you under the License to provide to third parties, for a fee or
-other consideration (including without limitation fees for hosting or
-consulting/ support services related to the Software), a product or service
-whose value derives, entirely or substantially, from the functionality of the
-Software. Any license notice or attribution required by the License must also
-include this Commons Clause License Condition notice.
-
-Software: dsa-ui
-
-License: MIT (Expat)
-
-Licensor: Ned Redmond

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,53 @@
+Please do not use this software for commercial projects. This software is
+exclusively for use by DSA members and allies. Assets including but not
+limited to the DSA logo and color palette information may only be used for
+official DSA business.
+
+=======================================================================
+
+MIT (Expat) License
+
+Copyright (c) 2022 Ned Redmond
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=======================================================================
+
+“Commons Clause” License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined
+below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under
+the License will not include, and the License does not grant to you, the right
+to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights
+granted to you under the License to provide to third parties, for a fee or
+other consideration (including without limitation fees for hosting or
+consulting/ support services related to the Software), a product or service
+whose value derives, entirely or substantially, from the functionality of the
+Software. Any license notice or attribution required by the License must also
+include this Commons Clause License Condition notice.
+
+Software: dsa-ui
+
+License: MIT (Expat)
+
+Licensor: Ned Redmond


### PR DESCRIPTION
I adapted some language from the license in the Manifold font file as well as from the design site, then combined MIT with Common Clause. I was thinking about using one of the license [here](https://ethicalsource.dev/licenses/), especially the Hippocratic or Do No Harm, but they are complex and none line up exactly with the goals of the DSA, so could be more trouble than they are worth.

Might be interesting for the NTC to craft their own software license.

Partially resolves #46 