### PR TITLE
Install Storybook dark mode addon

### DIFF
--- a/wc/.storybook/main.js
+++ b/wc/.storybook/main.js
@@ -4,7 +4,8 @@ module.exports = {
   ],
   "addons": [
     "@storybook/addon-links",
-    "@storybook/addon-essentials"
+    "@storybook/addon-essentials",
+    "storybook-dark-mode"
   ],
   "framework": "@storybook/web-components",
   "staticDirs": [{ from: '../dist/components/assets', to: 'assets/' }]

--- a/wc/package-lock.json
+++ b/wc/package-lock.json
@@ -40,6 +40,7 @@
         "prettier": "2.7.1",
         "puppeteer": "^19.2.2",
         "stencil-tailwind-plugin": "^1.6.0",
+        "storybook-dark-mode": "^1.1.2",
         "tailwindcss": "^3.1.8",
         "typescript": "^4.8.4"
       }
@@ -23167,6 +23168,34 @@
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
     },
+    "node_modules/storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -43857,6 +43886,22 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
+    },
+    "storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/wc/package.json
+++ b/wc/package.json
@@ -65,6 +65,7 @@
     "prettier": "2.7.1",
     "puppeteer": "^19.2.2",
     "stencil-tailwind-plugin": "^1.6.0",
+    "storybook-dark-mode": "^1.1.2",
     "tailwindcss": "^3.1.8",
     "typescript": "^4.8.4"
   },


### PR DESCRIPTION
Install https://storybook.js.org/addons/storybook-dark-mode for Storybook. This is for the Storybook UI itself—it doesn't help with testing our components for light mode/dark mode.